### PR TITLE
CYTHINF-32 Default Resource Properties Type

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ using Cythral.CloudFormation.CustomResource.Core;
 namespace Example
 {
     [CustomResource(
-        // Required. Sets the type to deserialize ResourceProperties to
+        // Optional. Sets the type to deserialize ResourceProperties to.
+        // If not set, this will default to the 'Properties' subclass
         ResourcePropertiesType = typeof(ExampleCustomResource.Properties),
         // Required if Grantees is set. Sets the grantee type to use
         // Possible values are Import or Literal

--- a/src/Generator/CustomResourceGenerator.cs
+++ b/src/Generator/CustomResourceGenerator.cs
@@ -27,9 +27,9 @@ namespace Cythral.CloudFormation.CustomResource.Generator
     public class CustomResourceGenerator : ICodeGenerator
     {
 
-        private INamedTypeSymbol ResourcePropertiesType = null;
+        private INamedTypeSymbol ResourcePropertiesType;
 
-        private string ResourcePropertiesTypeName = null;
+        private string ResourcePropertiesTypeName;
 
         private object[] Grantees { get; set; }
 

--- a/tests/Generator/GeneratorTests.csproj
+++ b/tests/Generator/GeneratorTests.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="AWSSDK.S3" Version="3.3.104.20" />
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
@@ -23,12 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cythral.CodeGeneration.Roslyn.Tool"
-                      Version="0.8.12-alpha-g888d1d7801"
-                      ReferenceOutputAssembly="false"
-                      OutputItemType="CodeGeneratorToolPathItem"
-                      SkipGetTargetFrameworkProperties="true"
-                      UndefineProperties="TargetFramework" />
+    <PackageReference Include="Cythral.CodeGeneration.Roslyn.Tool" Version="0.8.12-alpha-g888d1d7801" ReferenceOutputAssembly="false" OutputItemType="CodeGeneratorToolPathItem" SkipGetTargetFrameworkProperties="true" UndefineProperties="TargetFramework" />
   </ItemGroup>
 
   <Import Project="../../src/Generator/Generator.targets" />

--- a/tests/Generator/ResourcePropertiesTypeTests.cs
+++ b/tests/Generator/ResourcePropertiesTypeTests.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+using Cythral.CloudFormation.CustomResource.Attributes;
+using Cythral.CloudFormation.CustomResource.Core;
+
+using NUnit.Framework;
+using FluentAssertions;
+
+namespace Tests
+{
+    public partial class ResourcePropertiesTypeTests
+    {
+        [CustomResource]
+        public partial class DefaultedPropertiesTypeResource
+        {
+            public class Properties
+            {
+
+            }
+
+            public Task<Response> Create()
+            {
+                return Task.FromResult(new Response());
+            }
+
+            public Task<Response> Update()
+            {
+                return Task.FromResult(new Response());
+            }
+
+            public Task<Response> Delete()
+            {
+                return Task.FromResult(new Response());
+            }
+        }
+
+        [Test]
+        public void DefaultingWorks()
+        {
+            Type requestType = (
+                from member in typeof(DefaultedPropertiesTypeResource).GetProperties()
+                where member.Name == "Request"
+                select member.PropertyType
+            ).First();
+
+            Type resourcePropertiesType = (
+                from member in requestType.GetProperties()
+                where member.Name == "ResourceProperties"
+                select member.PropertyType
+            ).First();
+
+            resourcePropertiesType.Should().Be(typeof(DefaultedPropertiesTypeResource.Properties));
+        }
+    }
+}


### PR DESCRIPTION
This will default the ResourcePropertiesType attribute argument to the Properties subclass.  The defaulting does not happen until code generation happens.