### PR TITLE
Emit Permissions Txt File

### DIFF
--- a/src/Generator/CustomResourceGenerator.cs
+++ b/src/Generator/CustomResourceGenerator.cs
@@ -324,9 +324,8 @@ namespace Cythral.CloudFormation.CustomResource.Generator
 
             Resources.Add($"{ClassName}Role", role);
 
-            var permissionsFilePath = $"{context.BuildProperties["OutDir"]}/{ClassName}.permissions.yml";
-            var serializer = new SerializerBuilder().Build();
-            File.WriteAllText(permissionsFilePath, serializer.Serialize(permissions));
+            var permissionsFilePath = $"{context.BuildProperties["OutDir"]}/{ClassName}.permissions.txt";
+            File.WriteAllText(permissionsFilePath, string.Join('\n', permissions));
         }
 
         private MemberDeclarationSyntax GenerateHandleMethod()


### PR DESCRIPTION
Emits a txt file containing permissions delimited by newline instead of a yaml file. 