### PR TITLE
CYTHINF-82 Permissions Collection Fixes

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,14 +17,16 @@
         <PackageOutputPath>$(MSBuildThisFileDirectory)bin/Packages/$(Configuration)</PackageOutputPath>
         <RestorePackagesPath>$(MSBuildThisFileDirectory).nuget</RestorePackagesPath>
         <RestoreAdditionalProjectSources>@(CustomLocalFeed);$(RestoreAdditionalProjectSources)</RestoreAdditionalProjectSources>
-
+        
         <_ReleaseFeedLocation>$(MSBuildThisFileDirectory)bin/Packages/Release/</_ReleaseFeedLocation>
         <_DebugFeedLocation>$(MSBuildThisFileDirectory)bin/Packages/Debug/</_DebugFeedLocation>
+        <_CGRLocalLocation>/Users/tfisher/Documents/codegeneration.roslyn/bin/Packages/Debug</_CGRLocalLocation>
     </PropertyGroup>
 
     <ItemGroup>
         <CustomLocalFeed Include="$(_ReleaseFeedLocation)" Condition="Exists($(_ReleaseFeedLocation))" />
         <CustomLocalFeed Include="$(_DebugFeedLocation)" Condition="Exists($(_DebugFeedLocation))" />
+        <CustomLocalFeed Include="$(_CGRLocalLocation)" Condition="Exists($(_CGRLocalLocation))" />
     </ItemGroup>
     
     <ItemGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,8 @@
         <RepositoryType>git</RepositoryType>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
-        <CythralCodeGenerationRoslynVersion>0.8.12-alpha-g888d1d7801</CythralCodeGenerationRoslynVersion>
+        
+        <CythralCodeGenerationRoslynVersion>0.8.15-alpha-g06808178cf</CythralCodeGenerationRoslynVersion>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -20,13 +21,11 @@
         
         <_ReleaseFeedLocation>$(MSBuildThisFileDirectory)bin/Packages/Release/</_ReleaseFeedLocation>
         <_DebugFeedLocation>$(MSBuildThisFileDirectory)bin/Packages/Debug/</_DebugFeedLocation>
-        <_CGRLocalLocation>/Users/tfisher/Documents/codegeneration.roslyn/bin/Packages/Debug</_CGRLocalLocation>
     </PropertyGroup>
 
     <ItemGroup>
         <CustomLocalFeed Include="$(_ReleaseFeedLocation)" Condition="Exists($(_ReleaseFeedLocation))" />
         <CustomLocalFeed Include="$(_DebugFeedLocation)" Condition="Exists($(_DebugFeedLocation))" />
-        <CustomLocalFeed Include="$(_CGRLocalLocation)" Condition="Exists($(_CGRLocalLocation))" />
     </ItemGroup>
     
     <ItemGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
         
-        <CythralCodeGenerationRoslynVersion>0.8.15-alpha-g06808178cf</CythralCodeGenerationRoslynVersion>
+        <CythralCodeGenerationRoslynVersion>0.8.17-alpha-g40a87e6792</CythralCodeGenerationRoslynVersion>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,8 @@
 {
   "sdk": { "version": "3.1.200" },
   "msbuild-sdks": {
-    "Microsoft.Build.NoTargets": "1.0.94"
+    "Microsoft.Build.NoTargets": "1.0.94",
+    "Cythral.CodeGeneration.Roslyn.Plugin.Sdk": "0.8.15-alpha-g06808178cf",
+    "Cythral.CodeGeneration.Roslyn.PluginMetapackage.Sdk": "0.8.15-alpha-g06808178cf"
   }
 }

--- a/global.json
+++ b/global.json
@@ -2,7 +2,7 @@
   "sdk": { "version": "3.1.200" },
   "msbuild-sdks": {
     "Microsoft.Build.NoTargets": "1.0.94",
-    "Cythral.CodeGeneration.Roslyn.Plugin.Sdk": "0.8.15-alpha-g06808178cf",
-    "Cythral.CodeGeneration.Roslyn.PluginMetapackage.Sdk": "0.8.15-alpha-g06808178cf"
+    "Cythral.CodeGeneration.Roslyn.Plugin.Sdk": "0.8.17-alpha-g40a87e6792",
+    "Cythral.CodeGeneration.Roslyn.PluginMetapackage.Sdk": "0.8.17-alpha-g40a87e6792"
   }
 }

--- a/src/Attributes/Attributes.csproj
+++ b/src/Attributes/Attributes.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <ProjectName>Cythral.CloudFormation.CustomResource.Attributes</ProjectName>
@@ -8,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cythral.CodeGeneration.Roslyn.Attributes" Version="0.8.15-alpha-g06808178cf" />
+    <PackageReference Include="Cythral.CodeGeneration.Roslyn.Attributes" Version="$(CythralCodeGenerationRoslynVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Attributes/Attributes.csproj
+++ b/src/Attributes/Attributes.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <ProjectName>Cythral.CloudFormation.CustomResource.Attributes</ProjectName>
     <AssemblyName>$(ProjectName)</AssemblyName>
     <PackageId>$(ProjectName)</PackageId>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cythral.CodeGeneration.Roslyn.Attributes" Version="0.8.12-alpha-g888d1d7801" />
+    <PackageReference Include="Cythral.CodeGeneration.Roslyn.Attributes" Version="0.8.15-alpha-g06808178cf" />
   </ItemGroup>
 
 </Project>

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <ProjectName>Cythral.CloudFormation.CustomResource.Core</ProjectName>
     <AssemblyName>$(ProjectName)</AssemblyName>
     <PackageId>$(ProjectName)</PackageId>

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <ProjectName>Cythral.CloudFormation.CustomResource.Core</ProjectName>

--- a/src/Generator/CustomResourceGenerator.cs
+++ b/src/Generator/CustomResourceGenerator.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using System;
 using System.IO;
 using System.Collections.Generic;
@@ -5,6 +6,7 @@ using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
+using static System.Text.Json.JsonSerializer;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -38,7 +40,7 @@ namespace Cythral.CloudFormation.CustomResource.Generator
 
         private ClassDeclarationSyntax OriginalClass;
 
-        private string ClassName => OriginalClass.Identifier.ValueText;
+        private string ClassName;
 
         private AttributeData Data;
 
@@ -148,10 +150,6 @@ namespace Cythral.CloudFormation.CustomResource.Generator
             }
         }
 
-        public static Dictionary<string, Resource> Resources = new Dictionary<string, Resource>();
-
-        public static Dictionary<string, Output> Outputs = new Dictionary<string, Output>();
-
         public CustomResourceGenerator(AttributeData attributeData)
         {
             Requires.NotNull(attributeData, nameof(attributeData));
@@ -184,6 +182,8 @@ namespace Cythral.CloudFormation.CustomResource.Generator
         public Task<SyntaxList<MemberDeclarationSyntax>> GenerateAsync(TransformationContext context, IProgress<Diagnostic> progress, CancellationToken cancellationToken)
         {
             OriginalClass = (ClassDeclarationSyntax)context.ProcessingNode;
+            ClassName = OriginalClass.Identifier.ValueText;
+
             if (ResourcePropertiesType == null)
             {
                 ResourcePropertiesType = (
@@ -197,8 +197,6 @@ namespace Cythral.CloudFormation.CustomResource.Generator
             }
 
             var result = GeneratePartialClass();
-            AddResources(context);
-
             return Task.FromResult(SyntaxFactory.List(result));
 
             IEnumerable<MemberDeclarationSyntax> GeneratePartialClass()
@@ -225,13 +223,14 @@ namespace Cythral.CloudFormation.CustomResource.Generator
             }
         }
 
-        public static void OnComplete(OnCompleteContext context)
+        public void OnComplete(OnCompleteContext context)
         {
             var outputDirectory = context.BuildProperties["OutDir"].TrimEnd('/');
             var description = context.BuildProperties["StackDescription"];
             var templateFilePath = outputDirectory + "/" + context.BuildProperties["AssemblyName"] + ".template.yml";
             var permissionsFilePath = outputDirectory + "/permissions.yml";
             var errorFilePath = outputDirectory + "/customResourceTemplatingError.txt";
+            var diagnosticsFilePath = outputDirectory + "/customResourceDiagnostics.txt";
 
             try
             {
@@ -243,32 +242,34 @@ namespace Cythral.CloudFormation.CustomResource.Generator
                 .WithTypeConverter(new ImportValueTagConverter())
                 .Build();
 
+
                 File.WriteAllText(templateFilePath, serializer.Serialize(new
                 {
                     Description = description,
-                    Resources = Resources,
-                    Outputs = Outputs
+                    Resources = GetResources(context),
+                    Outputs = GetOutputs(context)
                 }));
             }
             catch (Exception e)
             {
-                System.IO.File.WriteAllText(errorFilePath, e.Message);
+                System.IO.File.WriteAllText(errorFilePath, e.Message + " " + e.StackTrace);
             }
         }
 
-        private void AddResources(TransformationContext context)
+        private Dictionary<string, Resource> GetResources(OnCompleteContext context)
         {
-            AddRoleResource(context);
+            var resources = new Dictionary<string, Resource>();
+            resources.Add($"{ClassName}Role", GetRoleResource(context));
 
             var codeDirectory = context.BuildProperties["OutDir"].TrimEnd('/') + "/publish";
             var version = context.BuildProperties["TargetFrameworkVersion"].Replace("v", "");
 
-            Resources.Add(ClassName + "Lambda", new Resource
+            resources.Add(ClassName + "Lambda", new Resource
             {
                 Type = "AWS::Lambda::Function",
                 Properties = new
                 {
-                    Handler = $"{context.BuildProperties["AssemblyName"]}::{context.ProcessingNode.GetFullName()}::Handle",
+                    Handler = $"{context.BuildProperties["AssemblyName"]}::${ClassName}::Handle",
                     Role = new GetAttTag() { Name = $"{ClassName}Role", Attribute = "Arn" },
                     Code = codeDirectory,
                     Runtime = $"dotnetcore{version}",
@@ -282,7 +283,7 @@ namespace Cythral.CloudFormation.CustomResource.Generator
                 {
                     var grantee = Grantees[i];
 
-                    Resources.Add($"{ClassName}Permission{i}", new Resource
+                    resources.Add($"{ClassName}Permission{i}", new Resource
                     {
                         Type = "AWS::Lambda::Permission",
                         Properties = new
@@ -295,25 +296,27 @@ namespace Cythral.CloudFormation.CustomResource.Generator
                 }
             }
 
-            Outputs.Add(ClassName + "LambdaArn", new Output(
-                value: new GetAttTag { Name = $"{ClassName}Lambda", Attribute = "Arn" },
-                name: new SubTag { Expression = $"${{AWS::StackName}}:{ClassName}LambdaArn" }
-            ));
+            return resources;
         }
 
-        private void AddRoleResource(TransformationContext context)
+        private Resource GetRoleResource(OnCompleteContext context)
         {
+
             var role = new Role()
             .AddTrustedServiceEntity("lambda.amazonaws.com")
             .AddManagedPolicy("arn:aws:iam::aws:policy/AWSLambdaExecute");
 
-            var collector = new PermissionsCollector(context);
+            var collector = new PermissionsCollector(context.Compilation);
 
-            try
+            foreach (var tree in context.Compilation.SyntaxTrees)
             {
-                collector.Visit(context.ProcessingNode);
+                try
+                {
+                    collector.Visit(tree.GetRoot());
+                }
+                catch (Exception) { }
             }
-            catch (Exception) { }
+
 
             var policy = new Policy($"{ClassName}PrimaryPolicy");
             var permissions = new HashSet<string> { "sts:AssumeRole" };
@@ -322,15 +325,26 @@ namespace Cythral.CloudFormation.CustomResource.Generator
             policy.AddStatement(Action: permissions);
             role.AddPolicy(policy);
 
-            Resources.Add($"{ClassName}Role", role);
+            var permissionsFilePath = $"{context.BuildProperties["OutDir"]}/{ClassName}.permissions.txt";
+            File.WriteAllText(permissionsFilePath, string.Join('\n', permissions));
+            return role;
+        }
 
-            Outputs.Add(ClassName + "RoleArn", new Output(
+        private Dictionary<string, Output> GetOutputs(OnCompleteContext context)
+        {
+            var outputs = new Dictionary<string, Output>();
+
+            outputs.Add(ClassName + "LambdaArn", new Output(
+                value: new GetAttTag { Name = $"{ClassName}Lambda", Attribute = "Arn" },
+                name: new SubTag { Expression = $"${{AWS::StackName}}:{ClassName}LambdaArn" }
+            ));
+
+            outputs.Add(ClassName + "RoleArn", new Output(
                 value: new GetAttTag { Name = $"{ClassName}Role", Attribute = "Arn" },
                 name: new SubTag { Expression = $"${{AWS::StackName}}:{ClassName}RoleArn" }
             ));
 
-            var permissionsFilePath = $"{context.BuildProperties["OutDir"]}/{ClassName}.permissions.txt";
-            File.WriteAllText(permissionsFilePath, string.Join('\n', permissions));
+            return outputs;
         }
 
         private MemberDeclarationSyntax GenerateHandleMethod()

--- a/src/Generator/Generator.csproj
+++ b/src/Generator/Generator.csproj
@@ -1,5 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Sdk Name="Cythral.CodeGeneration.Roslyn.Plugin.Sdk" Version="0.8.12-alpha-g888d1d7801" />
+  <Sdk Name="Cythral.CodeGeneration.Roslyn.Plugin.Sdk" Version="0.8.15-alpha-g06808178cf" />
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
@@ -14,7 +14,7 @@
   <ItemGroup>
     <None Include="Generator.props" Pack="true" PackagePath="build" KeepDuplicates="false" />
     <None Include="Generator.targets" Pack="true" PackagePath="build" KeepDuplicates="false" />
-    <PackageBuildFolderProjectImport Include="@(None->'%(Filename)%(Extension)')"/>
+    <PackageBuildFolderProjectImport Include="@(None->'%(Filename)%(Extension)')" />
   </ItemGroup>
 
   <ItemGroup>
@@ -25,7 +25,6 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="1.1.0" />
     <PackageReference Include="AWSSDK.Core" Version="3.3.106.4" />
     <PackageReference Include="McMaster.NETCore.Plugins" Version="1.2.0" />
-    <PackageReference Include="System.Text.Json" Version="4.7.1" />
     <PackageReference Include="Validation" Version="2.4.22" />
     <PackageReference Include="YamlDotNet" Version="6.1.2" />
   </ItemGroup>

--- a/src/Generator/Generator.csproj
+++ b/src/Generator/Generator.csproj
@@ -1,5 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Sdk Name="Cythral.CodeGeneration.Roslyn.Plugin.Sdk" Version="0.8.15-alpha-g06808178cf" />
+  <Sdk Name="Cythral.CodeGeneration.Roslyn.Plugin.Sdk" />
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>

--- a/src/Metapackage/Metapackage.csproj
+++ b/src/Metapackage/Metapackage.csproj
@@ -1,5 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Sdk Name="Cythral.CodeGeneration.Roslyn.PluginMetapackage.Sdk" Version="0.8.15-alpha-g06808178cf"/>
+  <Sdk Name="Cythral.CodeGeneration.Roslyn.PluginMetapackage.Sdk" />
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>

--- a/src/Metapackage/Metapackage.csproj
+++ b/src/Metapackage/Metapackage.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Sdk Name="Cythral.CodeGeneration.Roslyn.PluginMetapackage.Sdk" Version="0.8.12-alpha-g888d1d7801"/>
+  <Sdk Name="Cythral.CodeGeneration.Roslyn.PluginMetapackage.Sdk" Version="0.8.15-alpha-g06808178cf"/>
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <ProjectName>Cythral.CloudFormation.CustomResource</ProjectName>
     <AssemblyName>$(ProjectName)</AssemblyName>

--- a/tests/Generator/GeneratorTests.csproj
+++ b/tests/Generator/GeneratorTests.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cythral.CodeGeneration.Roslyn.Tool" Version="0.8.15-alpha-g06808178cf" ReferenceOutputAssembly="false" OutputItemType="CodeGeneratorToolPathItem" SkipGetTargetFrameworkProperties="true" UndefineProperties="TargetFramework" />
+    <PackageReference Include="Cythral.CodeGeneration.Roslyn.Tool" Version="$(CythralCodeGenerationRoslynVersion)" ReferenceOutputAssembly="false" OutputItemType="CodeGeneratorToolPathItem" SkipGetTargetFrameworkProperties="true" UndefineProperties="TargetFramework" />
   </ItemGroup>
 
   <Import Project="../../src/Generator/Generator.targets" />

--- a/tests/Generator/GeneratorTests.csproj
+++ b/tests/Generator/GeneratorTests.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cythral.CodeGeneration.Roslyn.Tool" Version="0.8.12-alpha-g888d1d7801" ReferenceOutputAssembly="false" OutputItemType="CodeGeneratorToolPathItem" SkipGetTargetFrameworkProperties="true" UndefineProperties="TargetFramework" />
+    <PackageReference Include="Cythral.CodeGeneration.Roslyn.Tool" Version="0.8.15-alpha-g06808178cf" ReferenceOutputAssembly="false" OutputItemType="CodeGeneratorToolPathItem" SkipGetTargetFrameworkProperties="true" UndefineProperties="TargetFramework" />
   </ItemGroup>
 
   <Import Project="../../src/Generator/Generator.targets" />


### PR DESCRIPTION
This includes some fixes for permissions collection:

- Syntax trees other than the one containing the class with the [CustomResource] attribute were not walked - this is now fixed and all syntax trees are traversed (ie other classes in the same project will now be looked at for iam permissions)

- Resources that referenced types on the partial class that were not there yet would not complete permissions collection successfully.  (ie if you referenced Request.ResourceProperties or the like, anything after that statement would not be traversed properly, unless you used full type names rather than the `var` keyword